### PR TITLE
feat: 🎸 Total Accumulator hook for totals row

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,24 @@
 								return format($input.value);
 							}
 						}
-					}
+                    },
+                    hooks: {
+                        columnTotal(columnValues, cell) {
+                            if (cell.colIndex === 5) {
+                                // calculated average for 5th column
+                                const sum = columnValues.reduce((acc, value) => {
+                                    if (typeof value === 'number') {
+                                        return acc + value
+                                    }
+                                    return acc
+                                }, 0);
+                                return sum / columnValues.length
+                            }
+                            if (cell.colIndex === 2) {
+                                return 'Total'
+                            }
+                        }
+                    }
 				});
 				console.log(performance.now() - start);
 

--- a/src/body-renderer.js
+++ b/src/body-renderer.js
@@ -10,7 +10,6 @@ export default class BodyRenderer {
         this.bodyScrollable = instance.bodyScrollable;
         this.footer = this.instance.footer;
         this.log = instance.log;
-        this.hooks = instance.hooks;
     }
 
     renderRows(rows) {

--- a/src/body-renderer.js
+++ b/src/body-renderer.js
@@ -91,7 +91,7 @@ export default class BodyRenderer {
             }
 
             let useDefaultAccumulator = !self.hooks.totalAccumulator;
-            let total = 0;
+            let total = null;
 
             if (!useDefaultAccumulator) {
                 const values = self.visibleRows.map(row => {
@@ -109,6 +109,9 @@ export default class BodyRenderer {
                 for (let i = 0; i < self.visibleRows.length; ++i) {
                     const cell = self.visibleRows[i][column.colIndex];
                     if (typeof cell.content === 'number') {
+                        if (total == null) {
+                            total = 0;
+                        }
                         total += cell.content;
                     }
                 }

--- a/src/body-renderer.js
+++ b/src/body-renderer.js
@@ -72,7 +72,7 @@ export default class BodyRenderer {
     getTotalRow() {
         const columns = this.datamanager.getColumns();
         const totalRowTemplate = columns.map(col => {
-            let content = 0;
+            let content = null;
             if (['_rowIndex', '_checkbox'].includes(col.id)) {
                 content = '';
             }
@@ -85,7 +85,7 @@ export default class BodyRenderer {
         });
 
         const totalRow = totalRowTemplate.map((cell, i) => {
-            if (typeof cell.content !== 'number') return cell;
+            if (cell.content === '') return cell;
 
             if (this.options.hooks.columnTotal) {
                 const columnValues = this.visibleRows.map(row => row[i].content);
@@ -99,6 +99,7 @@ export default class BodyRenderer {
             cell.content = this.visibleRows.reduce((acc, prevRow) => {
                 const prevCell = prevRow[i];
                 if (typeof prevCell.content === 'number') {
+                    if (acc == null) acc = 0;
                     return acc + prevCell.content;
                 }
                 return acc;

--- a/src/body-renderer.js
+++ b/src/body-renderer.js
@@ -10,6 +10,7 @@ export default class BodyRenderer {
         this.bodyScrollable = instance.bodyScrollable;
         this.footer = this.instance.footer;
         this.log = instance.log;
+        this.events = instance.events;
     }
 
     renderRows(rows) {
@@ -82,12 +83,25 @@ export default class BodyRenderer {
                 column: col
             };
         });
+
+        const rowCount = this.visibleRows.length;
         const totalRow = this.visibleRows.reduce((acc, prevRow) => {
             return acc.map((cell, i) => {
                 const prevCell = prevRow[i];
-                if (typeof prevCell.content === 'number') {
-                    cell.content += prevRow[i].content;
+
+                let useDefaultAccumulator = true;
+                if (this.events.accumulator) {
+                    const rowData = this.datamanager.getData(prevRow.meta.rowIndex);
+                    const res = this.events.accumulator(cell, prevCell, rowData, rowCount);
+                    if (res !== false) {
+                        useDefaultAccumulator = false;
+                    }
                 }
+
+                if (useDefaultAccumulator && typeof prevCell.content === 'number') {
+                    cell.content += prevCell.content;
+                }
+
                 if (!cell.format && prevCell.format) {
                     cell.format = prevCell.format;
                 }

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -59,13 +59,6 @@ class DataTable {
             options.events || {}
         );
         this.fireEvent = this.fireEvent.bind(this);
-
-        // custom user events
-        this.hooks = Object.assign(
-            {},
-            this.options.hooks || {},
-            options.events || {}
-        );
     }
 
     prepare() {

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -59,6 +59,13 @@ class DataTable {
             options.events || {}
         );
         this.fireEvent = this.fireEvent.bind(this);
+
+        // custom user events
+        this.hooks = Object.assign(
+            {},
+            this.options.hooks || {},
+            options.events || {}
+        );
     }
 
     prepare() {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -38,6 +38,9 @@ export default {
         onCheckRow(row) {},
         onDestroy() {}
     },
+    hooks: {
+        columnTotal: null
+    },
     sortIndicator: {
         asc: '↑',
         desc: '↓',


### PR DESCRIPTION
Added the option to add an event "accumulator" which will be used to calculate the totals row.
See the referenced PR for frappe for screenshots.

DataTable looks for `hooks.totalAccumulator`. If it finds the function, it will call it otherwise it will use it's default accumulator logic.

If the accumulator event function returns a `false`, the DataTable's default accumulator logic will be used.