### PR TITLE
fix: 🐛 Always listen to window resize event

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -225,6 +225,7 @@ $.measureTextWidth = function (text) {
     div.style.height = 'auto';
     div.style.width = 'auto';
     div.style.whiteSpace = 'nowrap';
+    div.style.top = '-9999px';
     div.innerText = text;
     document.body.appendChild(div);
     return div.clientWidth + 1;

--- a/src/style.js
+++ b/src/style.js
@@ -33,10 +33,7 @@ export default class Style {
     bindResizeWindow() {
         this.onWindowResize = this.onWindowResize.bind(this);
         this.onWindowResize = throttle(this.onWindowResize, 300);
-
-        if (this.options.layout === 'fluid') {
-            $.on(window, 'resize', this.onWindowResize);
-        }
+        $.on(window, 'resize', this.onWindowResize);
     }
 
     bindScrollHeader() {


### PR DESCRIPTION
**Problem:**
DataTable does not listen to Window Resize events when the layout is `fixed`. This causes horizontal scrolling problems with the bodyScrollable when the window is resized and the responsive UI makes the DataTable wrapper narrower.

Another problem was that the element created by `measureTextWidth` was taking up some height at the bottom of the page. I added `top: -9999px` to keep it out of the viewport. However, should this element be removed after inferring it's width?