### PR TITLE
fix: 🐛 treat undefined cells as empty strings for sorting purpose (#81)

### DIFF
--- a/src/datamanager.js
+++ b/src/datamanager.js
@@ -280,8 +280,11 @@ export default class DataManager {
         this.rowViewOrder.sort((a, b) => {
             const aIndex = a;
             const bIndex = b;
-            const aContent = this.getCell(colIndex, a).content;
-            const bContent = this.getCell(colIndex, b).content;
+
+            const tmpA = this.getCell(colIndex, a).content;
+            const tmpB = this.getCell(colIndex, b).content;
+            const aContent = typeof tmpA === 'undefined' ? '' : tmpA;
+            const bContent = typeof tmpB === 'undefined' ? '' : tmpB;
 
             if (sortOrder === 'none') {
                 return aIndex - bIndex;

--- a/src/datamanager.js
+++ b/src/datamanager.js
@@ -281,10 +281,10 @@ export default class DataManager {
             const aIndex = a;
             const bIndex = b;
 
-            const tmpA = this.getCell(colIndex, a).content;
-            const tmpB = this.getCell(colIndex, b).content;
-            const aContent = typeof tmpA === 'undefined' ? '' : tmpA;
-            const bContent = typeof tmpB === 'undefined' ? '' : tmpB;
+            let aContent = this.getCell(colIndex, a).content;
+            let bContent = this.getCell(colIndex, b).content;
+            aContent = aContent == null ? '' : aContent;
+            bContent = bContent == null ? '' : bContent;
 
             if (sortOrder === 'none') {
                 return aIndex - bIndex;


### PR DESCRIPTION
Before fix:
Refer to #81 

After fix:
Ascending:
![image](https://user-images.githubusercontent.com/24732036/61365803-050d6900-a891-11e9-8d06-ef9686747cce.png)

Descending:
![image](https://user-images.githubusercontent.com/24732036/61365849-19e9fc80-a891-11e9-9efd-2b174fbf995f.png)
