### PR TITLE
fix: 🐛 set content of empty cell to empty string for sorting

### DIFF
--- a/src/datamanager.js
+++ b/src/datamanager.js
@@ -280,8 +280,11 @@ export default class DataManager {
         this.rowViewOrder.sort((a, b) => {
             const aIndex = a;
             const bIndex = b;
-            const aContent = this.getCell(colIndex, a).content;
-            const bContent = this.getCell(colIndex, b).content;
+
+            let aContent = this.getCell(colIndex, a).content;
+            let bContent = this.getCell(colIndex, b).content;
+            aContent = aContent == null ? '' : aContent;
+            bContent = bContent == null ? '' : bContent;
 
             if (sortOrder === 'none') {
                 return aIndex - bIndex;


### PR DESCRIPTION
Fixes sorting of rows with empty cells such as:

<img width="455" alt="Screenshot 2020-03-16 at 2 20 55 PM" src="https://user-images.githubusercontent.com/19775888/76739099-c8806d00-6791-11ea-8cf5-1e7a5881a193.png">
