### PR TITLE
fix: 🐛 scroll for rtl direction

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -48,9 +48,7 @@ export default class Style {
             this._settingHeaderPosition = true;
 
             requestAnimationFrame(() => {
-                const { scrollLeft, scrollWidth, clientWidth } = e.target;
-
-                let left = this.options.direction === 'rtl' ? scrollWidth - clientWidth - scrollLeft : -scrollLeft;
+                const left = -e.target.scrollLeft;
 
                 $.style(this.header, {
                     transform: `translateX(${left}px)`


### PR DESCRIPTION
Before:
![rtl scroll bug](https://user-images.githubusercontent.com/19775888/92591878-50b47a80-f2bc-11ea-89e9-013d75a82dab.gif)



After:
![rtl scroll fix](https://user-images.githubusercontent.com/19775888/92591887-54480180-f2bc-11ea-9eff-c3099c6078a0.gif)


Tested for **Firefox** and **Chrome**