### PR TITLE
feat: translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,17 @@
 					dynamicRowHeight: true,
 					treeView: treeView,
 					showTotalRow: true,
+					// language: 'myLang',
+					// translations: {
+					// 	myLang: {
+					// 		"Sort Ascending": "Sort low to high",
+					// 		"{count} cells copied": {
+					// 			"1": "1 cell was copied",
+					// 			"2": "2 cells were copied",
+					// 			"default": "Many cells were copied"
+					// 		}
+					// 	}
+					// },
 					// filterRows(keyword, cells, colIndex) {
 					// 	return cells
 					// 		.filter(cell => cell.content.includes(keyword))

--- a/src/cellmanager.js
+++ b/src/cellmanager.js
@@ -133,9 +133,8 @@ export default class CellManager {
     bindCopyCellContents() {
         this.keyboard.on('ctrl+c', () => {
             const noOfCellsCopied = this.copyCellContents(this.$focusedCell, this.$selectionCursor);
-            const message = this.instance.translate('{0} cells copied', {
-                count: noOfCellsCopied,
-                args: [noOfCellsCopied]
+            const message = this.instance.translate('{count} cells copied', {
+                count: noOfCellsCopied
             });
 
             if (noOfCellsCopied) {

--- a/src/cellmanager.js
+++ b/src/cellmanager.js
@@ -133,7 +133,11 @@ export default class CellManager {
     bindCopyCellContents() {
         this.keyboard.on('ctrl+c', () => {
             const noOfCellsCopied = this.copyCellContents(this.$focusedCell, this.$selectionCursor);
-            const message = `${noOfCellsCopied} cell${noOfCellsCopied > 1 ? 's' : ''} copied`;
+            const message = this.instance.translate('{0} cells copied', {
+                count: noOfCellsCopied,
+                args: [noOfCellsCopied]
+            });
+
             if (noOfCellsCopied) {
                 this.instance.showToastMessage(message, 2);
             }

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -48,7 +48,9 @@ class DataTable {
         this.language = options.language || 'en';
         this.translationManager = new TranslationManager(this.language);
 
-        if (options.customTranslations) this.addCustomTranslations(options.customTranslations);
+        if (options.translations) {
+            this.translationManager.addTranslations(options.translations);
+        }
     }
 
     setDefaultOptions() {
@@ -260,10 +262,6 @@ class DataTable {
 
     translate(str, args) {
         return this.translationManager.translate(str, args);
-    }
-
-    addCustomTranslations(translations) {
-        this.translationManager.addCustomTranslations(translations);
     }
 }
 

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -46,7 +46,7 @@ class DataTable {
 
     initializeTranslations(options) {
         this.language = options.language || 'en';
-        this.translationManager = new TranslationManager(this);
+        this.translationManager = new TranslationManager(this.language);
 
         if (options.customTranslations) this.addCustomTranslations(options.customTranslations);
     }

--- a/src/datatable.js
+++ b/src/datatable.js
@@ -6,7 +6,8 @@ import RowManager from './rowmanager';
 import BodyRenderer from './body-renderer';
 import Style from './style';
 import Keyboard from './keyboard';
-import DEFAULT_OPTIONS from './defaults';
+import TranslationManager from './translationmanager';
+import getDefaultOptions from './defaults';
 
 let defaultComponents = {
     DataManager,
@@ -31,6 +32,8 @@ class DataTable {
             throw new Error('Invalid argument given for `wrapper`');
         }
 
+        this.initializeTranslations(options);
+        this.setDefaultOptions();
         this.buildOptions(options);
         this.prepare();
         this.initializeComponents();
@@ -41,23 +44,34 @@ class DataTable {
         }
     }
 
+    initializeTranslations(options) {
+        this.language = options.language || 'en';
+        this.translationManager = new TranslationManager(this);
+
+        if (options.customTranslations) this.addCustomTranslations(options.customTranslations);
+    }
+
+    setDefaultOptions() {
+        this.DEFAULT_OPTIONS = getDefaultOptions(this);
+    }
+
     buildOptions(options) {
         this.options = this.options || {};
 
         this.options = Object.assign(
-            {}, DEFAULT_OPTIONS,
+            {}, this.DEFAULT_OPTIONS,
             this.options || {}, options
         );
 
         options.headerDropdown = options.headerDropdown || [];
         this.options.headerDropdown = [
-            ...DEFAULT_OPTIONS.headerDropdown,
+            ...this.DEFAULT_OPTIONS.headerDropdown,
             ...options.headerDropdown
         ];
 
         // custom user events
         this.events = Object.assign(
-            {}, DEFAULT_OPTIONS.events,
+            {}, this.DEFAULT_OPTIONS.events,
             this.options.events || {},
             options.events || {}
         );
@@ -242,6 +256,14 @@ class DataTable {
         if (this.options.logs) {
             console.log.apply(console, arguments);
         }
+    }
+
+    translate(str, args) {
+        return this.translationManager.translate(str, args);
+    }
+
+    addCustomTranslations(translations) {
+        this.translationManager.addCustomTranslations(translations);
     }
 }
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,71 +1,73 @@
 import filterRows from './filterRows';
 import icons from './icons';
 
-export default {
-    columns: [],
-    data: [],
-    dropdownButton: icons.chevronDown,
-    headerDropdown: [
-        {
-            label: 'Sort Ascending',
-            action: function (column) {
-                this.sortColumn(column.colIndex, 'asc');
+export default function getDefaultOptions(instance) {
+    return {
+        columns: [],
+        data: [],
+        dropdownButton: icons.chevronDown,
+        headerDropdown: [
+            {
+                label: instance.translate('Sort Ascending'),
+                action: function (column) {
+                    this.sortColumn(column.colIndex, 'asc');
+                }
+            },
+            {
+                label: instance.translate('Sort Descending'),
+                action: function (column) {
+                    this.sortColumn(column.colIndex, 'desc');
+                }
+            },
+            {
+                label: instance.translate('Reset sorting'),
+                action: function (column) {
+                    this.sortColumn(column.colIndex, 'none');
+                }
+            },
+            {
+                label: instance.translate('Remove column'),
+                action: function (column) {
+                    this.removeColumn(column.colIndex);
+                }
             }
+        ],
+        events: {
+            onRemoveColumn(column) {},
+            onSwitchColumn(column1, column2) {},
+            onSortColumn(column) {},
+            onCheckRow(row) {},
+            onDestroy() {}
         },
-        {
-            label: 'Sort Descending',
-            action: function (column) {
-                this.sortColumn(column.colIndex, 'desc');
-            }
+        hooks: {
+            columnTotal: null
         },
-        {
-            label: 'Reset sorting',
-            action: function (column) {
-                this.sortColumn(column.colIndex, 'none');
-            }
+        sortIndicator: {
+            asc: '↑',
+            desc: '↓',
+            none: ''
         },
-        {
-            label: 'Remove column',
-            action: function (column) {
-                this.removeColumn(column.colIndex);
-            }
-        }
-    ],
-    events: {
-        onRemoveColumn(column) {},
-        onSwitchColumn(column1, column2) {},
-        onSortColumn(column) {},
-        onCheckRow(row) {},
-        onDestroy() {}
-    },
-    hooks: {
-        columnTotal: null
-    },
-    sortIndicator: {
-        asc: '↑',
-        desc: '↓',
-        none: ''
-    },
-    overrideComponents: {
-        // ColumnManager: CustomColumnManager
-    },
-    filterRows: filterRows,
-    freezeMessage: '',
-    getEditor: null,
-    serialNoColumn: true,
-    checkboxColumn: false,
-    clusterize: true,
-    logs: false,
-    layout: 'fixed', // fixed, fluid, ratio
-    noDataMessage: 'No Data',
-    cellHeight: 40,
-    minimumColumnWidth: 30,
-    inlineFilters: false,
-    treeView: false,
-    checkedRowStatus: true,
-    dynamicRowHeight: false,
-    pasteFromClipboard: false,
-    showTotalRow: false,
-    direction: 'ltr',
-    disableReorderColumn: false
+        overrideComponents: {
+            // ColumnManager: CustomColumnManager
+        },
+        filterRows: filterRows,
+        freezeMessage: '',
+        getEditor: null,
+        serialNoColumn: true,
+        checkboxColumn: false,
+        clusterize: true,
+        logs: false,
+        layout: 'fixed', // fixed, fluid, ratio
+        noDataMessage: instance.translate('No Data'),
+        cellHeight: 40,
+        minimumColumnWidth: 30,
+        inlineFilters: false,
+        treeView: false,
+        checkedRowStatus: true,
+        dynamicRowHeight: false,
+        pasteFromClipboard: false,
+        showTotalRow: false,
+        direction: 'ltr',
+        disableReorderColumn: false
+    };
 };

--- a/src/rowmanager.js
+++ b/src/rowmanager.js
@@ -133,7 +133,11 @@ export default class RowManager {
         const checkedRows = this.getCheckedRows();
         const count = checkedRows.length;
         if (count > 0) {
-            this.bodyRenderer.showToastMessage(`${count} row${count > 1 ? 's' : ''} selected`);
+            let message = this.instance.translate('{0} rows selected', {
+                count: count,
+                args: [count]
+            });
+            this.bodyRenderer.showToastMessage(message);
         } else {
             this.bodyRenderer.clearToastMessage();
         }

--- a/src/rowmanager.js
+++ b/src/rowmanager.js
@@ -133,9 +133,8 @@ export default class RowManager {
         const checkedRows = this.getCheckedRows();
         const count = checkedRows.length;
         if (count > 0) {
-            let message = this.instance.translate('{0} rows selected', {
-                count: count,
-                args: [count]
+            let message = this.instance.translate('{count} rows selected', {
+                count: count
             });
             this.bodyRenderer.showToastMessage(message);
         } else {

--- a/src/translationmanager.js
+++ b/src/translationmanager.js
@@ -13,13 +13,13 @@ export default class TranslationManager {
         this.translations = Object.assign(this.translations, translations);
     }
 
-    translate(str, args) {
-        let translation = (this.translations[this.language] && this.translations[this.language][str]) || str;
+    translate(sourceText, args) {
+        let translation = (this.translations[this.language] && this.translations[this.language][sourceText]) || sourceText;
 
         if (typeof translation === 'object') {
             translation = args && args.count ?
                 this.getPluralizedTranslation(translation, args.count) :
-                str;
+                sourceText;
         }
 
         return format(translation, args || {});

--- a/src/translationmanager.js
+++ b/src/translationmanager.js
@@ -1,46 +1,12 @@
 import { format } from './utils';
+import getTranslationsJSON from './translations';
 
 export default class TranslationManager {
     constructor(instance) {
         this.instance = instance;
         this.language = this.instance.language;
 
-        this.translations = {
-            en: {
-                'Sort Ascending': 'Sort Ascending',
-                'Sort Descending': 'Sort Descending',
-                'Reset sorting': 'Reset sorting',
-                'Remove column': 'Remove column',
-                'No Data': 'No Data',
-                '{0} cells copied': {
-                    0: '{0} cells copied',
-                    1: '{0} cell copied',
-                    default: '{0} cells copied'
-                },
-                '{0} rows selected': {
-                    0: '{0} rows selected',
-                    1: '{0} row selected',
-                    default: '{0} rows selected'
-                }
-            },
-            de: {
-                'Sort Ascending': 'Aufsteigend sortieren',
-                'Sort Descending': 'Absteigend sortieren',
-                'Reset sorting': 'Sortierung zurücksetzen',
-                'Remove column': 'Spalte entfernen',
-                'No Data': 'Keine Daten',
-                '{0} cells copied': {
-                    0: '{0} zellen kopiert',
-                    1: '{0} zelle kopiert',
-                    default: '{0} zellen kopiert'
-                },
-                '{0} rows selected': {
-                    0: '{0} zeilen ausgewählt',
-                    1: '{0} zeile ausgewählt',
-                    default: '{0} zeilen ausgewählt'
-                }
-            }
-        };
+        this.translations = getTranslationsJSON();
     }
 
     addCustomTranslations(translations) {
@@ -56,7 +22,7 @@ export default class TranslationManager {
                 str;
         }
 
-        return format(translation, args ? args.args : []);
+        return format(translation, args || {});
     }
 
     getPluralizedTranslation(translations, count) {

--- a/src/translationmanager.js
+++ b/src/translationmanager.js
@@ -22,6 +22,23 @@ export default class TranslationManager {
                     1: '{0} row selected',
                     default: '{0} rows selected'
                 }
+            },
+            de: {
+                'Sort Ascending': 'Aufsteigend sortieren',
+                'Sort Descending': 'Absteigend sortieren',
+                'Reset sorting': 'Sortierung zurücksetzen',
+                'Remove column': 'Spalte entfernen',
+                'No Data': 'Keine Daten',
+                '{0} cells copied': {
+                    0: '{0} zellen kopiert',
+                    1: '{0} zelle kopiert',
+                    default: '{0} zellen kopiert'
+                },
+                '{0} rows selected': {
+                    0: '{0} zeilen ausgewählt',
+                    1: '{0} zeile ausgewählt',
+                    default: '{0} zeilen ausgewählt'
+                }
             }
         };
     }

--- a/src/translationmanager.js
+++ b/src/translationmanager.js
@@ -2,11 +2,11 @@ import { format } from './utils';
 import getTranslationsJSON from './translations';
 
 export default class TranslationManager {
-    constructor(instance) {
-        this.instance = instance;
-        this.language = this.instance.language;
+    constructor(language) {
+        this.language = language;
 
         this.translations = getTranslationsJSON();
+        window.t = this.translations;
     }
 
     addCustomTranslations(translations) {
@@ -14,7 +14,8 @@ export default class TranslationManager {
     }
 
     translate(sourceText, args) {
-        let translation = (this.translations[this.language] && this.translations[this.language][sourceText]) || sourceText;
+        let translation = (this.translations[this.language] &&
+            this.translations[this.language][sourceText]) || sourceText;
 
         if (typeof translation === 'object') {
             translation = args && args.count ?

--- a/src/translationmanager.js
+++ b/src/translationmanager.js
@@ -1,0 +1,48 @@
+import { format } from './utils';
+
+export default class TranslationManager {
+    constructor(instance) {
+        this.instance = instance;
+        this.language = this.instance.language;
+
+        this.translations = {
+            en: {
+                'Sort Ascending': 'Sort Ascending',
+                'Sort Descending': 'Sort Descending',
+                'Reset sorting': 'Reset sorting',
+                'Remove column': 'Remove column',
+                'No Data': 'No Data',
+                '{0} cells copied': {
+                    0: '{0} cells copied',
+                    1: '{0} cell copied',
+                    default: '{0} cells copied'
+                },
+                '{0} rows selected': {
+                    0: '{0} rows selected',
+                    1: '{0} row selected',
+                    default: '{0} rows selected'
+                }
+            }
+        };
+    }
+
+    addCustomTranslations(translations) {
+        this.translations = Object.assign(this.translations, translations);
+    }
+
+    translate(str, args) {
+        let translation = (this.translations[this.language] && this.translations[this.language][str]) || str;
+
+        if (typeof translation === 'object') {
+            translation = args && args.count ?
+                this.getPluralizedTranslation(translation, args.count) :
+                str;
+        }
+
+        return format(translation, args ? args.args : []);
+    }
+
+    getPluralizedTranslation(translations, count) {
+        return translations[count] || translations['default'];
+    }
+};

--- a/src/translationmanager.js
+++ b/src/translationmanager.js
@@ -1,15 +1,13 @@
 import { format } from './utils';
-import getTranslationsJSON from './translations';
+import getTranslations from './translations';
 
 export default class TranslationManager {
     constructor(language) {
         this.language = language;
-
-        this.translations = getTranslationsJSON();
-        window.t = this.translations;
+        this.translations = getTranslations();
     }
 
-    addCustomTranslations(translations) {
+    addTranslations(translations) {
         this.translations = Object.assign(this.translations, translations);
     }
 

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -5,12 +5,10 @@
 	"Remove column": "Spalte entfernen",
 	"No Data": "Keine Daten",
 	"{count} cells copied": {
-		"0": "{count} Zellen kopiert",
 		"1": "{count} Zelle kopiert",
 		"default": "{count} Zellen kopiert"
 	},
 	"{count} rows selected": {
-		"0": "{count} Zeilen ausgewählt",
 		"1": "{count} Zeile ausgewählt",
 		"default": "{count} Zeilen ausgewählt"
 	}

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -1,0 +1,17 @@
+{
+	"Sort Ascending": "Aufsteigend sortieren",
+	"Sort Descending": "Absteigend sortieren",
+	"Reset sorting": "Sortierung zurücksetzen",
+	"Remove column": "Spalte entfernen",
+	"No Data": "Keine Daten",
+	"{count} cells copied": {
+		"0": "{count} Zellen kopiert",
+		"1": "{count} Zelle kopiert",
+		"default": "{count} Zellen kopiert"
+	},
+	"{count} rows selected": {
+		"0": "{count} Zeilen ausgewählt",
+		"1": "{count} Zeile ausgewählt",
+		"default": "{count} Zeilen ausgewählt"
+	}
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5,12 +5,10 @@
 	"Remove column": "Remove column",
 	"No Data": "No Data",
 	"{count} cells copied": {
-		"0": "{count} cells copied",
 		"1": "{count} cell copied",
 		"default": "{count} cells copied"
 	},
 	"{count} rows selected": {
-		"0": "{count} rows selected",
 		"1": "{count} row selected",
 		"default": "{count} rows selected"
 	}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,0 +1,17 @@
+{
+	"Sort Ascending": "Sort Ascending",
+	"Sort Descending": "Sort Descending",
+	"Reset sorting": "Reset sorting",
+	"Remove column": "Remove column",
+	"No Data": "No Data",
+	"{count} cells copied": {
+		"0": "{count} cells copied",
+		"1": "{count} cell copied",
+		"default": "{count} cells copied"
+	},
+	"{count} rows selected": {
+		"0": "{count} rows selected",
+		"1": "{count} row selected",
+		"default": "{count} rows selected"
+	}
+}

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -1,0 +1,15 @@
+{
+	"Sort Ascending": "Trier par ordre croissant",
+	"Sort Descending": "Trier par ordre décroissant",
+	"Reset sorting": "Réinitialiser le tri",
+	"Remove column": "Supprimer colonne",
+	"No Data": "Pas de données",
+	"{count} cells copied": {
+		"1": "{count} cellule copiée",
+		"default": "{count} cellules copiées"
+	},
+	"{count} rows selected": {
+		"1": "{count} ligne sélectionnée",
+		"default": "{count} lignes sélectionnées"
+	}
+}

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -1,0 +1,9 @@
+import en from './en.json';
+import de from './de.json';
+
+export default function getTranslationsJSON() {
+    return {
+        en: en,
+        de: de
+    };
+};

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -3,11 +3,11 @@ import de from './de.json';
 import fr from './fr.json';
 import it from './it.json';
 
-export default function getTranslationsJSON() {
+export default function getTranslations() {
     return {
-        en: en,
-        de: de,
-        fr: fr,
-        it: it,
+        en,
+        de,
+        fr,
+        it,
     };
 };

--- a/src/translations/index.js
+++ b/src/translations/index.js
@@ -1,9 +1,13 @@
 import en from './en.json';
 import de from './de.json';
+import fr from './fr.json';
+import it from './it.json';
 
 export default function getTranslationsJSON() {
     return {
         en: en,
-        de: de
+        de: de,
+        fr: fr,
+        it: it,
     };
 };

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -1,0 +1,15 @@
+{
+	"Sort Ascending": "Ordinamento ascendente",
+	"Sort Descending": "Ordinamento decrescente",
+	"Reset sorting": "Azzeramento ordinamento",
+	"Remove column": "Rimuovi colonna",
+	"No Data": "Nessun dato",
+	"{count} cells copied": {
+		"1": "Copiato {count} cella",
+		"default": "{count} celle copiate"
+	},
+	"{count} rows selected": {
+		"1": "{count} linea selezionata",
+		"default": "{count} linee selezionate"
+	}
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,3 +138,11 @@ export function numberSortAsc(a, b) {
 export function stripHTML(html) {
     return html.replace(/<[^>]*>/g, '');
 };
+
+export function format(str, args) {
+    if (!str) return str;
+
+    return str.replace(/{(\d+)}/g, function (match, number) {
+        return typeof args[number] !== 'undefined' ? args[number] : match;
+    });
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,7 +142,10 @@ export function stripHTML(html) {
 export function format(str, args) {
     if (!str) return str;
 
-    return str.replace(/{(\d+)}/g, function (match, number) {
-        return typeof args[number] !== 'undefined' ? args[number] : match;
+    Object.keys(args).forEach(arg => {
+        let regex = new RegExp(`{(${arg})}`, 'g');
+        str = str.replace(regex, args[arg]);
     });
+
+    return str;
 };


### PR DESCRIPTION
- Adds translations support to datatable.
- Language can be passed as parameter while initializing the datatable.
- Translations can be added in translations.js.
- Custom translations can be added using `customTranslations` when initializing the datatable.
- Handling Pluralization:
    - to translate strings that can have a plural word like `row/rows`, multiple strings can be defined for counts, ie for a particular count, if a string is defined, it'll be used. eg: if the total row count is 0, the string for key 0 will be using in  `{0} rows selected` the translations and if there exists no key like 10, default key will be used for translation. This way multiple use cases can be handled
```
    this.translations = {
            en: {
                '{count} rows selected': {
                    0: '{count} rows selected',
                    1: '{count} row selected',
                    default: '{count} rows selected'
                }
            }
        };
```