### PR TITLE
fix: Link to Hompage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "bugs": {
     "url": "https://github.com/frappe/datatable/issues"
   },
-  "homepage": "https://frappe.github.io/datatable",
+  "homepage": "https://frappe.io/datatable",
   "dependencies": {
     "hyperlist": "^1.0.0-beta",
     "lodash": "^4.17.5",


### PR DESCRIPTION
Updated the link to point to `https://frappe.io/datatable`.

