### PR TITLE
fix(minor): Keyboard Interaction

### DIFF
--- a/src/cellmanager.js
+++ b/src/cellmanager.js
@@ -643,7 +643,7 @@ export default class CellManager {
     }
 
     focusCellInDirection(direction) {
-        if (!this.$focusedCell) {
+        if (!this.$focusedCell || (this.$editingCell && ['left', 'right', 'up', 'down'].includes(direction))) {
             return false;
         } else if (this.$editingCell && ['tab', 'shift+tab'].includes(direction)) {
             this.deactivateEditing();

--- a/src/cellmanager.js
+++ b/src/cellmanager.js
@@ -517,8 +517,11 @@ export default class CellManager {
                 }
 
                 promise = valuePromise.then((value) => {
-                    const done = editor.setValue(value, rowIndex, col);
                     const oldValue = this.getCell(colIndex, rowIndex).content;
+
+                    if (oldValue === value) return;
+
+                    const done = editor.setValue(value, rowIndex, col);
 
                     // update cell immediately
                     this.updateCell(colIndex, rowIndex, value);


### PR DESCRIPTION
1. Don't save on pressing **enter** if the value is not changed
2. While in editing value we should be able to use **left, right, up, and down** keys instead of changing focus to the next cell.

|  Before  |  After  |
|---------|-------|
|  ![DatatableKeyBug](https://user-images.githubusercontent.com/30859809/172634489-dceb5490-a73f-4724-a09f-562a6a4fbe3a.gif)  |  ![DatatableKeyFix](https://user-images.githubusercontent.com/30859809/172634534-578b261c-b06d-439f-9b63-3aa70261f710.gif)  |