### PR TITLE
feat: 🎸 check all filtered rows

### DIFF
--- a/src/rowmanager.js
+++ b/src/rowmanager.js
@@ -113,7 +113,13 @@ export default class RowManager {
 
         // update internal map
         if (toggle) {
-            this.checkMap = Array.from(Array(this.getTotalRows())).map(c => value);
+            if (this.datamanager._filteredRows) {
+                this.datamanager._filteredRows.forEach(f => {
+                    this.checkRow(f, toggle);
+                });
+            } else {
+                this.checkMap = Array.from(Array(this.getTotalRows())).map(c => value);
+            }
         } else {
             this.checkMap = [];
         }


### PR DESCRIPTION
When datatable has filters applied, and the "check all" is used,
it will check only the rows that match the filters.

Before:
![before](https://user-images.githubusercontent.com/21109597/191745391-98ac15d6-a101-44c7-9d47-060de58e5087.gif)

After:
![after](https://user-images.githubusercontent.com/21109597/191745759-f2897496-67f7-488a-a658-eea39dc5f241.gif)
