### PR TITLE
fix: show datatable cell content in tooltip on hover

### DIFF
--- a/src/cellmanager.js
+++ b/src/cellmanager.js
@@ -870,7 +870,7 @@ export default class CellManager {
             isHeader ? `dt-cell__content--header-${colIndex}` : `dt-cell__content--col-${colIndex}`
         ].join(' ');
 
-        return `
+        let cellContentHTML = `
             <div class="${className}">
                 ${contentHTML}
                 ${sortIndicator}
@@ -879,6 +879,16 @@ export default class CellManager {
             </div>
             ${editCellHTML}
         `;
+
+        let div = document.createElement('div');
+        div.innerHTML = contentHTML;
+
+        let textContent = div.textContent;
+        textContent = textContent.replace(/\s+/g, ' ').trim();
+
+        cellContentHTML = cellContentHTML.replace('>', ` title="${textContent}">`);
+
+        return cellContentHTML;
     }
 
     getEditCellHTML(colIndex) {


### PR DESCRIPTION
Show data table cell content in the tooltip on the hover
<img width="1279" alt="image" src="https://user-images.githubusercontent.com/30859809/214551757-05eb3f1f-f66b-4383-bfc0-ba01c5d0124b.png">
