### PR TITLE
fix: escape html to get tooltip text

### DIFF
--- a/src/cellmanager.js
+++ b/src/cellmanager.js
@@ -2,7 +2,8 @@ import {
     copyTextToClipboard,
     makeDataAttributeString,
     throttle,
-    linkProperties
+    linkProperties,
+    escapeHTML,
 } from './utils';
 import $ from './dom';
 import icons from './icons';
@@ -886,7 +887,7 @@ export default class CellManager {
         let textContent = div.textContent;
         textContent = textContent.replace(/\s+/g, ' ').trim();
 
-        cellContentHTML = cellContentHTML.replace('>', ` title="${textContent}">`);
+        cellContentHTML = cellContentHTML.replace('>', ` title="${escapeHTML(textContent)}">`);
 
         return cellContentHTML;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -151,16 +151,16 @@ export function format(str, args) {
 };
 
 export function escapeHTML(txt) {
-    if (!txt) return "";
+    if (!txt) return '';
     let escapeHtmlMapping = {
-        "&": "&amp;",
-        "<": "&lt;",
-        ">": "&gt;",
-        '"': "&quot;",
-        "'": "&#39;",
-        "/": "&#x2F;",
-        "`": "&#x60;",
-        "=": "&#x3D;",
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;',
+        '/': '&#x2F;',
+        '`': '&#x60;',
+        '=': '&#x3D;',
     };
 
     return String(txt).replace(/[&<>"'`=/]/g, (char) => escapeHtmlMapping[char] || char);

--- a/src/utils.js
+++ b/src/utils.js
@@ -149,3 +149,19 @@ export function format(str, args) {
 
     return str;
 };
+
+export function escapeHTML(txt) {
+    if (!txt) return "";
+    let escapeHtmlMapping = {
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+        "/": "&#x2F;",
+        "`": "&#x60;",
+        "=": "&#x3D;",
+    };
+
+    return String(txt).replace(/[&<>"'`=/]/g, (char) => escapeHtmlMapping[char] || char);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -164,4 +164,4 @@ export function escapeHTML(txt) {
     };
 
     return String(txt).replace(/[&<>"'`=/]/g, (char) => escapeHtmlMapping[char] || char);
-}
+};


### PR DESCRIPTION
Escape " ' etc to get correct tooltip text