### PR TITLE
fix: get content value for specific fieldtypes

### DIFF
--- a/src/filterRows.js
+++ b/src/filterRows.js
@@ -34,7 +34,7 @@ function getFilterMethod(rows, filter) {
     const getFormattedValue = cell => {
         let formatter = CellManager.getCustomCellFormatter(cell);
         if (formatter && cell.content) {
-            cell.html = formatter(cell.content, rows[cell.rowIndex], cell.column, rows[cell.rowIndex]);
+            cell.html = formatter(cell.content, rows[cell.rowIndex], cell.column, rows[cell.rowIndex], true);
             return stripHTML(cell.html);
         }
         return cell.content || '';


### PR DESCRIPTION
**Issue:** While filtering we always compare the filter string with the formatted value of the cell but some cell takes too much time to get the formatted value which results in a broken page.

For some field types like the Link field we do not have to get formatted value, we can check with the content value. This PR adds a flag while getting the value we pass `flag for_filter=true` as a fifth parameter. The main logic will be handled based on the flag at the framework side which is through this PR #