### PR TITLE
fix: 🐛 Apply range filter only for numbers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2018 Frappé Technologies Pvt. Ltd. <developers@frappe.io>
+Copyright (c) 2018 Frappe Technologies Pvt. Ltd. <developers@frappe.io>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="ie=edge">
-	<title>Frappé DataTable</title>
+	<title>Frappe DataTable</title>
 	<style>
 		body {
 			font-family: 'Tahoma';
@@ -17,7 +17,7 @@
 </head>
 
 <body>
-	<h1>Frappé DataTable</h1>
+	<h1>Frappe DataTable</h1>
 	<button onclick="datatable.render()">Render Table</button>
 	<button onclick="datatable.refresh()">Refresh Data</button>
 	<button onclick="switchToTreeView()" data-action="treeview">TreeView</button>

--- a/src/filterRows.js
+++ b/src/filterRows.js
@@ -189,7 +189,7 @@ function guessFilter(keyword = '') {
         }
     }
 
-    if (keyword.split(':').length === 2) {
+    if (keyword.split(':').length === 2 && keyword.split(':').every(v => isNumber(v.trim()))) {
         compareString = keyword.split(':');
         return {
             type: 'range',


### PR DESCRIPTION
Apply range filter only if there are numbers on either side of ":" character. The fixes the issue where it tries to apply range filter even while diretly filtering records with ":" characters in it.

**Before:**
<img width="850" alt="Screenshot 2023-09-11 at 1 01 10 PM" src="https://github.com/frappe/datatable/assets/13928957/06dbf736-b175-4d7a-9fcd-5bd907e8d09f">

**After:**
<img width="866" alt="Screenshot 2023-09-11 at 12 54 55 PM" src="https://github.com/frappe/datatable/assets/13928957/cb47ca8b-232d-401a-bce2-10402b94f22e">
