### PR TITLE
Make datatable vertical height dependent on viewport height

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -30,7 +30,7 @@
 }
 
 .dt-scrollable {
-    height: 40vw;
+    height: calc(100vh - 450px);
     overflow: auto;
     border-top: 2px solid var(--dt-border-color);
 


### PR DESCRIPTION
This pull request sets the datatable height based on the viewport height. It is still not adjustable from the outside world as mentioned in https://github.com/frappe/datatable/issues/5 but it does improve the height in the ERPNext General Ledger