### PR TITLE
fix: pass filter instead of true

### DIFF
--- a/src/filterRows.js
+++ b/src/filterRows.js
@@ -34,7 +34,7 @@ function getFilterMethod(rows, filter) {
     const getFormattedValue = cell => {
         let formatter = CellManager.getCustomCellFormatter(cell);
         if (formatter && cell.content) {
-            cell.html = formatter(cell.content, rows[cell.rowIndex], cell.column, rows[cell.rowIndex], true);
+            cell.html = formatter(cell.content, rows[cell.rowIndex], cell.column, rows[cell.rowIndex], filter);
             return stripHTML(cell.html);
         }
         return cell.content || '';


### PR DESCRIPTION
filter contains the search keyword and the type of filter which can be used to avoid formatting to reduce load.
e.g. 
```filter = { type: "contains", text: "Home" }```