### PR TITLE
perf: rendering large data

### DIFF
--- a/src/body-renderer.js
+++ b/src/body-renderer.js
@@ -21,8 +21,11 @@ export default class BodyRenderer {
             return;
         }
 
+        // Create a temporary set for faster lookups.
+        // We can't change this.visibleRowIndices as it would be breaking for users.
+        let visibleRowIndicesSet = new Set(this.visibleRowIndices);
         const rowViewOrder = this.datamanager.rowViewOrder.map(index => {
-            if (this.visibleRowIndices.includes(index)) {
+            if (visibleRowIndicesSet.has(index)) {
                 return index;
             }
             return null;


### PR DESCRIPTION
visibleRowIndices.includes is major culprit in rendering data table.
This is because for every row it does this computation, so instead of
O(N) operation it becomes O(N^2)
