### PR TITLE
fix: Added isValidDate to filter date range ":"

### DIFF
--- a/src/filterRows.js
+++ b/src/filterRows.js
@@ -194,12 +194,18 @@ function guessFilter(keyword = '') {
         }
     }
 
-    if (keyword.split(':').length === 2 && keyword.split(':').every(v => isNumber(v.trim()))) {
-        compareString = keyword.split(':');
-        return {
-            type: 'range',
-            text: compareString.map(v => v.trim())
-        };
+    if (keyword.split(':').length === 2) {
+        function isValidDate(dateString) {
+            var date = new Date(dateString);
+            return date instanceof Date && !isNaN(date);
+        }
+        if (keyword.split(':').every(v => isNumber(v.trim()) || isValidDate(v.trim()) )) {
+            compareString = keyword.split(':');
+            return {
+                type: 'range',
+                text: compareString.map(v => v.trim())
+            };
+        }
     }
 
     return {


### PR DESCRIPTION
In this pull request it was changed to only work for numbers:
https://github.com/frappe/datatable/pull/176

But what about date filters that previously worked?
Example: 2024/01/05:2024/01/10