### PR TITLE
feat: add serialNoColumnLabel option to customize serial number column header label

### DIFF
--- a/src/datamanager.js
+++ b/src/datamanager.js
@@ -70,7 +70,7 @@ export default class DataManager {
         if (this.options.serialNoColumn && !this.hasColumnById('_rowIndex')) {
             let cell = {
                 id: '_rowIndex',
-                content: '',
+                content: this.options.serialNoColumnLabel || '',
                 align: 'center',
                 editable: false,
                 resizable: false,

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -54,6 +54,7 @@ export default function getDefaultOptions(instance) {
         freezeMessage: '',
         getEditor: null,
         serialNoColumn: true,
+        serialNoColumnLabel: '',
         checkboxColumn: false,
         clusterize: true,
         logs: false,


### PR DESCRIPTION
Related to https://github.com/frappe/frappe/issues/35724

## Summary

  - Add `serialNoColumnLabel` option to customize the serial number column header text
  - Defaults to empty string for backwards compatibility with existing implementations

  ## Usage

  ```javascript
  var datatable = new DataTable('#table', {
      serialNoColumn: true,
      serialNoColumnLabel: 'No.',  // Custom label
      columns: [...],
      data: [...]
  });

  Options

  | Option              | Type   | Default | Description                           |
  |---------------------|--------|---------|---------------------------------------|
  | serialNoColumnLabel | String | ''      | Header label for serial number column |

To fix above issue, should I add `No.` as default to this table or should we edit from frappe frontend code?