### PR TITLE
fix: handle absent serialNo column in filter input #218

### DIFF
--- a/src/rowmanager.js
+++ b/src/rowmanager.js
@@ -360,7 +360,7 @@ export default class RowManager {
         let title = `title="Filter based on ${props.name || 'Index'}"`;
         const dataAttr = makeDataAttributeString(props);
         return `<input class="dt-filter dt-input" type="text" ${dataAttr} tabindex="1"
-            ${props.colIndex === 0 ? 'disabled' : title} />`;
+            ${props.colIndex < this.datamanager.getStandardColumnCount() ? 'disabled' : title} />`;
     }
 
     selector(rowIndex) {


### PR DESCRIPTION
Use getStandardColumnCount to dynamically determine if the first column shoould be disabled, preventing data columns from being  incorrectly locked when serialNoColumn is false.

✅ Closes: #218