### PR TITLE
fix(datamanager): enable sr. no. cols to be resizable

### DIFF
--- a/src/datamanager.js
+++ b/src/datamanager.js
@@ -74,14 +74,11 @@ export default class DataManager {
                 content: this.options.serialNoColumnLabel || '',
                 align: 'center',
                 editable: false,
-                resizable: false,
+                resizable: true,
                 focusable: false,
                 dropdown: false,
                 sticky: true
             };
-            if (this.options.data.length > 1000) {
-                cell.resizable = true;
-            }
             this.columns.push(cell);
         }
     }


### PR DESCRIPTION
This PR enables resizable serial no. columns. 

**Before**:

Serial No. Columns were explicitly blocked from being resizable (were only resizable if data.length > 1000).


**After**:


https://github.com/user-attachments/assets/7427b7db-4ae2-44f1-a40f-e0e7771e5261


closes Ticket #69524