### PR TITLE
fix(style): raise dropdown z-index above sticky header cells

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -235,7 +235,7 @@
     &__list {
         position: fixed;
         min-width: 8rem;
-        z-index: 1;
+        z-index: 10;
         cursor: pointer;
         background-color: var(--dt-cell-bg);
         border-radius: var(--dt-border-radius);


### PR DESCRIPTION
Resolve: #235

---
`.dt-dropdown__list` had z-index: 1 which placed it behind `.dt-cell--sticky-top` (z-index: 4), causing the column action menu to render underneath sticky header cells like the checkbox.
 
 ---
 **Before Fix**
 
 https://github.com/user-attachments/assets/8d7aba00-c2a3-48ad-b75e-02289d770dfa

 
 **After Fix**
 
https://github.com/user-attachments/assets/cbde27ce-10d5-46b5-898d-181170285601



