### PR TITLE
fix: raise toast z-index above sticky columns

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -273,6 +273,7 @@
     bottom: var(--dt-spacer-3);
     left: 50%;
     transform: translateX(-50%);
+    z-index: 5;
 
     &__message {
         display: inline-block;


### PR DESCRIPTION
before:

<img width="747" height="427" alt="Screenshot 2026-07-12 at 2 04 45 PM" src="https://github.com/user-attachments/assets/c8a5adb8-51f4-4519-919f-2332b740efe9" />

after:

<img width="1080" height="411" alt="Screenshot 2026-07-13 at 2 20 12 AM" src="https://github.com/user-attachments/assets/97ef852b-76f4-41d6-b8f6-026f711179b9" />
